### PR TITLE
More fallbacks after a url fails, including different data nodes

### DIFF
--- a/sdt/bin/sddmdefault.py
+++ b/sdt/bin/sddmdefault.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
+#!/usr/share/python/synda/sdt/bin/python
+#jfp was
 # -*- coding: ISO-8859-1 -*-
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
@@ -49,6 +50,7 @@ class Download():
     @classmethod
     def start_transfer_script(cls,tr):
 
+        sdlog.info("JFPDMDEF-001","Will download url=%s"%(tr.url,))
         if sdconfig.fake_download:
             tr.status=sdconst.TRANSFER_STATUS_DONE
             tr.error_msg=""
@@ -165,33 +167,30 @@ class Download():
 
                 sdlog.error("SDDMDEFA-190","%s (file_id=%d,url=%s,local_path=%s)"%(tr.error_msg,tr.file_id,tr.url,tr.local_path))
             else:
+                pass
 
-                if sdconfig.next_url_on_error:
-
-
-                    # Hack
-                    #
-                    # Notes
-                    #     - Only active for gridftp url to prevent having useless log message (i.e. there is currently no url switching mecanism for http url)
-                    #     - We need a log here so to have a trace of the original failed transfer (i.e. in case the url-switch succeed, the error msg will be reset)
-                    #
-                    transfer_protocol=sdutils.get_transfer_protocol(tr.url)
-                    if transfer_protocol==sdconst.TRANSFER_PROTOCOL_GRIDFTP:
-                        sdlog.info("SDDMDEFA-088","Transfer failed: try to use another url (%s)"%str(tr))
+            if sdconfig.next_url_on_error:
 
 
-                    result=sdnexturl.run(tr)
-                    if result:
-                        tr.status=sdconst.TRANSFER_STATUS_WAITING
-                        tr.error_msg=''
-                    else:
-                        tr.status=sdconst.TRANSFER_STATUS_ERROR
-                        tr.error_msg='Error occurs during download.'
+                # Hack
+                #
+                # Notes
+                #     - We need a log here so to have a trace of the original failed transfer (i.e. in case the url-switch succeed, the error msg will be reset)
+                #
+                sdlog.info("SDDMDEFA-088","Transfer failed: try to use another url (%s)"%str(tr))
 
-
+                result=sdnexturl.run(tr)
+                if result:
+                    tr.status=sdconst.TRANSFER_STATUS_WAITING
+                    tr.error_msg=''
                 else:
                     tr.status=sdconst.TRANSFER_STATUS_ERROR
                     tr.error_msg='Error occurs during download.'
+
+
+            else:
+                tr.status=sdconst.TRANSFER_STATUS_ERROR
+                tr.error_msg='Error occurs during download.'
 
 def end_of_transfer(tr):
 

--- a/sdt/bin/sdexception.py
+++ b/sdt/bin/sdexception.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
+#!/usr/share/python/synda/sdt/bin/python
+#jfp was
 # -*- coding: ISO-8859-1 -*-
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
@@ -26,6 +27,8 @@ class SDException(Exception):
 class FileNotFoundException(SDException):
     pass
 class HttpUrlNotFoundException(SDException):
+    pass
+class NextUrlNotFoundException(SDException):
     pass
 class NoTransferWaitingException(SDException):
     pass

--- a/sdt/bin/sdnexturl.py
+++ b/sdt/bin/sdnexturl.py
@@ -1,15 +1,17 @@
-#!/usr/bin/env python
+#!/usr/share/python/synda/sdt/bin/python
+#jfp was
 # -*- coding: ISO-8859-1 -*-
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright (c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
 """This script contains next url routine."""
+# multiple changes by JfP to make fallback more flexible.
 
 import argparse
 import sdlog
@@ -17,6 +19,8 @@ import sdutils
 import sdconst
 import sdquicksearch
 import sdexception
+import sdconfig
+import sqlite3
 
 def run(tr):
     """
@@ -24,77 +28,107 @@ def run(tr):
         True: url has been switched to a new one
         False: nothing changed (same url)
     """
-    transfer_protocol=sdutils.get_transfer_protocol(tr.url)
-    if transfer_protocol==sdconst.TRANSFER_PROTOCOL_GRIDFTP:
-        # GRIDFTP url
-
-        try:
-            next_url(tr)
-            return True
-        except sdexception.FileNotFoundException as e:
-            sdlog.info("SDNEXTUR-001","Cannot switch url for %s (FileNotFoundException)"%(tr.file_functional_id,))
-            return False
-        except sdexception.HttpUrlNotFoundException as e:
-            sdlog.info("SDNEXTUR-002","Cannot switch url for %s (HttpUrlNotFoundException)"%(tr.file_functional_id,))
-            return False
-        except Exception as e:
-            sdlog.info("SDNEXTUR-003","Unknown exception (file_functional_id=%s,exception=%s)"%(tr.file_functional_id,str(e)))
-            return False
-
-    else:
-        # most likely HTTP url
-        #
-        # nothing to do
-        # (i.e. no fallback for now in this module for http url)
-
+    try:
+        conn = sqlite3.connect(sdconfig.db_file,120)  # 2 minute timeout
+        c = conn.cursor()
+        c.execute("INSERT INTO failed_url(url,file_id) VALUES (?,"+
+                  "(SELECT file_id FROM file WHERE file_functional_id=?))",
+                  (tr.url, tr.file_functional_id) )
+        conn.commit()
+    except sqlite3.IntegrityError as e:
+        # url is already in the failed_url table
+        sdlog.info("JFPNEXTUR-01","During database operations, IntegrityError %s"%(e,))
+    except Exception as e:
+        sdlog.info("JFPNEXTUR-02","During database operations, unknown exception %s"%(e,))
         return False
+    finally:
+        c.close()
 
-def next_url(tr):
-    urls=get_urls(tr.file_functional_id)
-    urls=remove_unsupported_url(urls)
+    try:
+        next_url(tr,conn)
+        return True
+    except sdexception.FileNotFoundException as e:
+        sdlog.info("SDNEXTUR-001","Cannot switch url for %s (FileNotFoundException)"%(tr.file_functional_id,))
+        return False
+    except sdexception.NextUrlNotFoundException as e:
+        sdlog.info("SDNEXTUR-002","Cannot switch url for %s (NextUrlNotFoundException)"%(tr.file_functional_id,))
+        return False
+    except Exception as e:
+        sdlog.info("SDNEXTUR-003","Unknown exception (file_functional_id=%s,exception=%s)"%(tr.file_functional_id,str(e)))
+        conn.close()
+        return False
+    finally:
+        conn.close()
 
-    if 'url_http' in urls:
+def next_url(tr,conn):
+    all_urlps=get_urls(tr.file_functional_id) # [[url1,protocol1],[url2,protocol2],...]
+    sdlog.info("JFPNEXTUR-03","all_urpls= %s"%(all_urlps,))
+    c = conn.cursor()
+    fus = c.execute("SELECT url FROM failed_url WHERE file_id="+
+                  "(SELECT file_id FROM file WHERE file_functional_id=?)",
+                    (tr.file_functional_id,))
+    failed_urls = [fu[0] for fu in fus.fetchall()]
+    sdlog.info("JFPNEXTUR-04","failed_urls= %s"%(failed_urls,))
+    urlps = [urlp for urlp in all_urlps if urlp[0] not in failed_urls]
+    # ... Note that list comprehensions preserve order.
+    urls=remove_unsupported_url(urlps)
+    # At this point urls is just a list of urls.  We no longer have to keep track of the
+    # protocol because only http and gsiftp are possible (OpenDAP is a different protocol
+    # but it also uses a http url).
+    
+    if len(urls)>0:
         old_url=tr.url
-        new_url=urls['url_http']
-
+        new_url=urls[0]
         tr.url=new_url
-
         sdlog.info("SDNEXTUR-004","Url successfully switched (file_functional_id=%s,old_url=%s,new_url=%s)"%(tr.file_functional_id,old_url,new_url))
     else:
-        sdlog.info("SDNEXTUR-006","Http url not found (file_functional_id=%s)"%(tr.file_functional_id,))
-        raise sdexception.HttpUrlNotFoundException()
+        sdlog.info("SDNEXTUR-006","Next url not found (file_functional_id=%s)"%(tr.file_functional_id,))
+        raise sdexception.NextUrlNotFoundException()
 
-def remove_unsupported_url(urls):
-
+def remove_unsupported_url(urlps):
     # remove opendap url (opendap is not used in synda for now)
-    try:
-        del urls['url_opendap']
-    except Exception as e:
-        pass
-
-    return urls
+    return [ urlp[0] for urlp in urlps if urlp[1].find('opendap')<0 ]
 
 def get_urls(file_functional_id):
-    result=sdquicksearch.run(parameter=['limit=1','fields=%s'%url_fields,'type=File','instance_id=%s'%file_functional_id],post_pipeline_mode=None)
+    """returns a prioritized list of [url,protocol] where each url can supply the specified file"""
+
+    result=sdquicksearch.run(parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%file_functional_id],post_pipeline_mode=None)
     li=result.get_files()
-    if len(li)>0:
-        file_=li[0]
+    sdlog.info("JFPNEXTUR-05","sdquicksearch returned %s sets of file urls: %s"%(len(li),li))
+    # result looks like
+    # [ {protocol11:url11, protocol12:url12, attached_parameters:dict, score:number, type:'File',
+    #    size:number} }, {[another dict of the same format}, {another dict},... ]
+    # with no more than limit=4 items in the list, and no more than three protocols.  
+    # We'll return something like urlps = [ [url1,protocol1], [url2,protocol2],... ]
+    # The return value could be an empty list.
+    # Note: These nested lists are ugly; it's just a quick way to code something up.
 
-        # remove non url attributes
-        try:
-            del file_['attached_parameters']
-        except Exception as e:
-            pass
+    urlps = []
+    for dic in li:
+        urlps += [ [dic[key],key] for key in dic.keys() if key.find('url_')>=0 ]
+        # ... protocol keys are one of 'url_opendap', 'url_http', 'url_gridftp'
 
-        urls=file_
+    return prioritize_urlps( urlps )
 
-    else:
-        sdlog.info("SDNEXTUR-090","File not found (file_functional_id=%s)"%(tr.file_functional_id,))
-        raise sdexception.FileNotFoundException()
+url_fields=','.join(sdconst.URL_FIELDS)  # used for the sdquicksearch call above
 
-    return urls
+def prioritize_urlps( urlps ):
+    """Orders a list urlps so that the highest-priority urls come first.  urlps is a list of
+    lists of the form [url,protocol].  First, GridFTP urls are preferred over everything else.
+    Then, prefer some data nodes over others."""
+    def priprotocol(protocol):
+        if protocol.find('gridftp')>0:  return 0
+        if protocol.find('http')>0:     return 1
+        return 2
+    def priurl(url):
+        if url.find('llnl')>0:  return 0
+        if url.find('ceda')>0:  return 1
+        if url.find('dkrz')>0:  return 2
+        if url.find('ipsl')>0:  return 3
+        if url.find('nci')>0:   return 4
+        return 5
+    return sorted( urlps, key=(lambda urlp: (priprotocol(urlp[1]), priurl(urlp[0]))) )
 
-url_fields=','.join(sdconst.URL_FIELDS)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
These changes are not ready to be merged, but it works for me.

When Synda cannot get data from the supplied data node with the requested protocol, it can now try other data nodes and protocols.  Previously, the only such "fallback" which was supported was a switch from gsiftp to http at the same data node.

The more_fallbacks branch fits my needs but in several respects it is not ready for a general release.
1.  It always prefers gsiftp over http.
2. The maximum number of data nodes and their relative priorities are hard-coded.
3. There is a list of failed urls, saved in the database.  There may well be a better place for them.  For this to work requires the database to have another table; see below.  The table should be cleared periodically and isn't yet - once a file is downloaded, the urls for that file are useless; and any url is worth a future retry because the server failure may be temporary.
  CREATE TABLE failed_url ( url_id INTEGER PRIMARY KEY, url TEXT, file_id INTEGER );
  CREATE UNIQUE INDEX idx_failed_url_1 ON failed_url (url);
4. My emacs couldn't find the specified character set, so I removed the character set specification in each file.  Obviously this is not a good long-term solution.
5. There is more logging than we would want in a completed module.
