### PR TITLE
Per-datanode maximum on parallel downloads

### DIFF
--- a/sdt/bin/sdcfbuilder.py
+++ b/sdt/bin/sdcfbuilder.py
@@ -1,4 +1,4 @@
-#!/usr/share/python/synda/sdt/bin/python
+#!/usr/bin/env python
 
 ##################################
 #  @program        synda

--- a/sdt/bin/sdcfbuilder.py
+++ b/sdt/bin/sdcfbuilder.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
-# -*- coding: ISO-8859-1 -*-
+#!/usr/share/python/synda/sdt/bin/python
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
@@ -79,6 +78,7 @@ def create_configuration_file_sample(path):
 
     config.add_section('download')
     config.set('download', 'max_parallel_download', '8')
+    config.set('download', 'max_parallel_download_per_datanode', '8')
     config.set('download', 'hpss', '1')
     config.set('download', 'http_fallback', 'false')
     config.set('download', 'gridftp_opt', '')

--- a/sdt/bin/sdcfloader.py
+++ b/sdt/bin/sdcfloader.py
@@ -1,4 +1,4 @@
-#!/usr/share/python/synda/sdt/bin/python
+#!/usr/bin/env python
 
 ##################################
 #  @program        synda

--- a/sdt/bin/sdcfloader.py
+++ b/sdt/bin/sdcfloader.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
-# -*- coding: ISO-8859-1 -*-
+#!/usr/share/python/synda/sdt/bin/python
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
@@ -34,6 +33,7 @@ def load(configuration_file,credential_file):
 # TODO: replace default options DICTIONNARY below with a default options FILE
 # (pb with options below is that they are available in all sections)
 default_options={'max_parallel_download':'8',
+                 'max_parallel_download_per_datanode':'8',
                  'user':'',
                  'group':'',
                  'hpss':'0',

--- a/sdt/bin/sddao.py
+++ b/sdt/bin/sddao.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
-# -*- coding: ISO-8859-1 -*-
+#!/usr/share/python/synda/sdt/bin/python
 
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 
@@ -172,8 +171,12 @@ def get_file(file_functional_id=None):
 
     return f
 
-def get_one_waiting_transfer():
-    li=sdfiledao.get_files(limit=1,status=sdconst.TRANSFER_STATUS_WAITING)
+def get_one_waiting_transfer( datanode=None ):
+    if datanode is None:
+        li=sdfiledao.get_files( limit=1, status=sdconst.TRANSFER_STATUS_WAITING )
+    else:
+        li=sdfiledao.get_files( limit=1, status=sdconst.TRANSFER_STATUS_WAITING,\
+                                data_node=datanode )
 
     if len(li)==0:
         raise NoTransferWaitingException()

--- a/sdt/bin/sddao.py
+++ b/sdt/bin/sddao.py
@@ -1,4 +1,4 @@
-#!/usr/share/python/synda/sdt/bin/python
+#!/usr/bin/env python
 
 ##################################
 #  @program        synda

--- a/sdt/bin/sdfilequery.py
+++ b/sdt/bin/sdfilequery.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: ISO-8859-1 -*-
+#!/usr/share/python/synda/sdt/bin/python
+# -*- coding: utf-8 -*-
 
 ##################################
 #  @program        synda
@@ -21,6 +21,7 @@ import sdapp
 import sddb
 from sdtools import print_stderr
 import sdconst
+import sdlog
 
 def transfer_running_count(conn=sddb.conn):
     return transfer_status_count(status=sdconst.TRANSFER_STATUS_RUNNING,conn=conn)
@@ -40,6 +41,17 @@ def transfer_status_count(status=None,conn=sddb.conn):
     count=rs[0]
     c.close()
     return count
+
+def transfer_running_count_by_datanode( conn=sddb.conn ):
+    c = conn.cursor()
+    q = "SELECT data_node FROM file WHERE (status='running' OR status='waiting') GROUP BY data_node"
+    c.execute(q)
+    rcs = {r[0]:0 for r in c.fetchall()}
+    q = "SELECT data_node,COUNT(data_node) FROM file WHERE status='running' GROUP BY data_node"
+    c.execute(q)
+    rcs.update( {r[0]:r[1] for r in c.fetchall()} )
+    c.close()
+    return rcs
 
 def get_download_status(project=None):
     li=[]

--- a/sdt/bin/sdfilequery.py
+++ b/sdt/bin/sdfilequery.py
@@ -1,5 +1,4 @@
-#!/usr/share/python/synda/sdt/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
 ##################################
 #  @program        synda

--- a/sdt/bin/sdfilequery.py
+++ b/sdt/bin/sdfilequery.py
@@ -3,8 +3,8 @@
 ##################################
 #  @program        synda
 #  @description    climate models data transfer program
-#  @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                             All Rights Reserved”
+#  @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                             All Rights Reserved"
 #  @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
 

--- a/sdt/bin/sdtask.py
+++ b/sdt/bin/sdtask.py
@@ -1,5 +1,4 @@
-#!/usr/share/python/synda/sdt/bin/python
-# -*- coding: ISO-8859-1 -*-
+#!/usr/bin/env python
 
 ##################################
 # @program        synda

--- a/sdt/bin/sdtask.py
+++ b/sdt/bin/sdtask.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/share/python/synda/sdt/bin/python
 # -*- coding: ISO-8859-1 -*-
 
 ##################################
 # @program        synda
 # @description    climate models data transfer program
-# @copyright      Copyright “(c)2009 Centre National de la Recherche Scientifique CNRS. 
-#                            All Rights Reserved”
+# @copyright      Copyright "(c)2009 Centre National de la Recherche Scientifique CNRS. 
+#                            All Rights Reserved"
 # @license        CeCILL (https://raw.githubusercontent.com/Prodiguer/synda/master/sdt/doc/LICENSE)
 ##################################
  
@@ -119,6 +119,7 @@ def pre_transfer_check_list(tr):
             sdlog.info("SYNDTASK-188","Local file already exists: transfer aborted (lfae_mode=abort,local_file=%s)"%tr.get_full_local_path())
 
             tr.status=sdconst.TRANSFER_STATUS_ERROR
+            tr.priority -= 1
             tr.error_msg="Local file already exists: transfer aborted (lfae_mode=abort)"
             tr.end_date=sdtime.now()
             sdfiledao.update_file(tr)
@@ -131,19 +132,44 @@ def pre_transfer_check_list(tr):
 def transfers_begin():
     transfers=[]
 
-    new_transfer_count=max_transfer - sdfilequery.transfer_running_count() # compute how many new transfer can be started
+    # how many new transfers can be started:
+    new_transfer_count=max_transfer - sdfilequery.transfer_running_count()
+    # datanode_count[datanode], is number of running transfers for a data node:
+    datanode_count = sdfilequery.transfer_running_count_by_datanode()
     if new_transfer_count>0:
+        transfers_needed = new_transfer_count
         for i in range(new_transfer_count):
-            try:
-                tr=sddao.get_one_waiting_transfer()
+            for datanode in datanode_count.keys():
+                try:
+                    # Handle per-datanode maximum number of transfers:
+                    try:
+                        new_count = max_datanode_count - datanode_count[datanode]
+                    except KeyError:
+                        sdlog.info("SYNDTASK-189","key error on datanode %s, legal keys are %s"%
+                                   (datanode,datanode_count.keys()) )
+                        new_count = max_datanode_count
+                    if new_count<=0:
+                        continue
 
-                prepare_transfer(tr)
+                    tr=sddao.get_one_waiting_transfer( datanode )
 
-                if pre_transfer_check_list(tr):
-                    sdfiledao.update_file(tr)
-                    transfers.append(tr)
-            except NoTransferWaitingException, e:
-                pass
+                    prepare_transfer(tr)
+
+                    if pre_transfer_check_list(tr):
+                        sdfiledao.update_file(tr)
+                        transfers.append(tr)
+
+                    if datanode in datanode_count:
+                        datanode_count[datanode] += 1
+                    else:
+                        datanode_count[datanode] = 1
+                    transfers_needed -= 1
+                    if transfers_needed <= 0:
+                        break
+                except NoTransferWaitingException, e:
+                    pass
+            if transfers_needed <= 0:
+                break
 
     dmngr.transfers_begin(transfers)
 
@@ -168,6 +194,7 @@ def fatal_exception():
 # init.
 
 max_transfer=sdconfig.config.getint('download','max_parallel_download')
+max_datanode_count = sdconfig.config.getint('download','max_parallel_download_per_datanode')
 lfae_mode=sdconfig.config.get('behaviour','lfae_mode')
 
 dmngr=get_download_manager()


### PR DESCRIPTION
In large-scale replication work, there often is a problem where all permitted downloads are taken up by a slow server with big files.  But to get a good transfer rate, you must keep all data nodes active at all times.  The simple way to do this is to set a maximum number of parallel downloads separately for each data node.  This does not preclude setting an overall maximum as before.