### PR TITLE
Allow sddaemon to log messages in transfer.log

### DIFF
--- a/sdt/bin/sddaemon.py
+++ b/sdt/bin/sddaemon.py
@@ -203,7 +203,9 @@ def unprivileged_user_mode():
 os.umask(0002)
 
 pidfile=daemon.pidfile.PIDLockFile(sdconfig.daemon_pid_file)
-context=daemon.DaemonContext(working_directory=sdconfig.tmp_folder, pidfile=pidfile,)
+log_stdout=open("{}/{}".format(sdconfig.log_folder,sdconst.LOGFILE_CONSUMER), "a+")
+log_stderr=open("{}/{}".format(sdconfig.log_folder,sdconst.LOGFILE_CONSUMER), "a+")
+context=daemon.DaemonContext(working_directory=sdconfig.tmp_folder, pidfile=pidfile,stdout=log_stdout,stderr=log_stderr)
 context.signal_map={ signal.SIGTERM: terminate, }
 
 # retrieve unprivileged user from configuration file if any


### PR DESCRIPTION
Actually error messages from the DaemonContext are not logged anywhere. This pull request allows DaemonContext to log messages in `transfer.log`.