### PR TITLE
Support changes to a newer database version, 3.10.

### DIFF
--- a/sdt/bin/sdapp.py
+++ b/sdt/bin/sdapp.py
@@ -40,7 +40,7 @@ def cleanup():
 os.umask(0002)
 
 name='transfer'
-version='3.9'
+version='3.10'
 sdapputils.set_exception_handler()
 
 # maybe remove the two mkdir below as it is a bit overkill

--- a/sdt/bin/sddbversionutils.py
+++ b/sdt/bin/sddbversionutils.py
@@ -10,47 +10,19 @@
 ##################################
 
 """This module contains database versioning utils routines.
-
-Note
-    Version pattern must be "x.x" with x an integer.
 """
 
-def _str2int(version):
-    assert isinstance(version,basestring)
-    return int(float(version)*10)
+from distutils.version import LooseVersion
 
-def _int2str(version):
-    assert isinstance(version,int)
-    return str(float(version)/10)
-
-def inclusive_range(vb,ve):
-    """Same as range(), except that end bound is included."""
-
-    assert isinstance(vb,int)
-    assert isinstance(ve,int)
-
-    if ve > vb:
-
-        # we need to transform 've', because range() func do not return last value
-        #
-        ve+=1 # e.g. if last was 33, it is now 34 and 34 will be stripped by range()
-
-        return range(vb,ve)
-
-    else:
-        # in this case, return empty list as no upgrade needed
-
-        return []
-
-def version_range(version_begin,version_end):
-    """Return version range between version_begin and version_end."""
-
-    vb=_str2int(version_begin)
-    ve=_str2int(version_end)
-
-    li=[_int2str(i) for i in inclusive_range(vb,ve)]
-
-    return li
+def version_range( versions, version_begin, version_end ):
+    """Returns a sorted list of all versions between version_begin and version_end, inclusive.
+    The inputs and outputs are version strings."""
+    vs = [ LooseVersion(v) for v in versions ]
+    vbegin = LooseVersion(version_begin)
+    vend  =  LooseVersion(version_end)
+    vrange = [ v for v in vs if v>=vbegin and v<=vend ]
+    vrange.sort()
+    return [vs.vstring for vs in vrange]
 
 # --- version table I/O --- #
 
@@ -76,4 +48,6 @@ def update_db_version(conn,version):
 # init.
 
 if __name__ == '__main__':
-    print version_range('3.0','4.2')
+    import sddbversion
+    print sddbversion.upgrade_procs.keys()
+    print version_range(sddbversion.upgrade_procs.keys(), '3.0','4.2')


### PR DESCRIPTION
This will automatically change the database to version 3.10, in order to support the more_fallbacks branch.

The code to handle version numbers has been replaced with code using distutils.version.  This should be more flexible.