### PR TITLE
Reduce priority for errors

### DIFF
--- a/sdt/bin/sddmdefault.py
+++ b/sdt/bin/sddmdefault.py
@@ -103,6 +103,7 @@ class Download():
 
                     if incorrect_checksum_action=="remove":
                         tr.status=sdconst.TRANSFER_STATUS_ERROR
+                        tr.priority -= 1
                         tr.error_msg="File corruption detected: local checksum doesn't match remote checksum"
 
                         # remove file from local repository
@@ -163,6 +164,7 @@ class Download():
                 # must be implemented (directly in synda, or using crontab).
                 #
                 tr.status=sdconst.TRANSFER_STATUS_ERROR
+                tr.priority -= 1
                 tr.error_msg="Download process has been killed"
 
                 sdlog.error("SDDMDEFA-190","%s (file_id=%d,url=%s,local_path=%s)"%(tr.error_msg,tr.file_id,tr.url,tr.local_path))
@@ -185,11 +187,13 @@ class Download():
                     tr.error_msg=''
                 else:
                     tr.status=sdconst.TRANSFER_STATUS_ERROR
+                    tr.priority -= 1
                     tr.error_msg='Error occurs during download.'
 
 
             else:
                 tr.status=sdconst.TRANSFER_STATUS_ERROR
+                tr.priority -= 1
                 tr.error_msg='Error occurs during download.'
 
 def end_of_transfer(tr):

--- a/sdt/bin/sddmgo.py
+++ b/sdt/bin/sddmgo.py
@@ -72,6 +72,7 @@ def transfers_end():
 
                         if incorrect_checksum_action=="remove":
                             tr.status=sdconst.TRANSFER_STATUS_ERROR
+                            tr.priority -= 1
                             tr.error_msg="File corruption detected: local checksum doesn't match remote checksum"
 
                             # remove file from local repository
@@ -101,6 +102,7 @@ def transfers_end():
 
             elif status == "FAILED":
                 tr.status = sdconst.TRANSFER_STATUS_ERROR
+                tr.priority -= 1
                 tr.error_msg = "Error occurs during download."
 
                 sdlog.info("SDDMGLOB-101", "Transfer failed (%s)" % str(tr))


### PR DESCRIPTION
Reduce priority by 1 whenever status is changed to sdconst.TRANSFER_STATUS_ERROR.  (This was already done in sdtask.py.)
This ensures that a file which had a download error, will not be retried until the other files have been downloaded.   This ensures that as many files as possible would be downloaded, even if a retry were issued immediately.  Other desirable side effects, even after an immediate retry, are a delay between download attempts, and that errors tend to be near each other in the log file.
This pull request addresses issue 82.