### PR TITLE
Wildcard in filename for index search

### DIFF
--- a/sdt/bin/sdnexturl.py
+++ b/sdt/bin/sdnexturl.py
@@ -37,9 +37,9 @@ def run(tr):
         conn.commit()
     except sqlite3.IntegrityError as e:
         # url is already in the failed_url table
-        sdlog.info("JFPNEXTUR-01","During database operations, IntegrityError %s"%(e,))
+        sdlog.info("SDNEXTUR-001","During database operations, IntegrityError %s"%(e,))
     except Exception as e:
-        sdlog.info("JFPNEXTUR-02","During database operations, unknown exception %s"%(e,))
+        sdlog.info("SDNEXTUR-002","During database operations, unknown exception %s"%(e,))
         return False
     finally:
         c.close()
@@ -48,13 +48,13 @@ def run(tr):
         next_url(tr,conn)
         return True
     except sdexception.FileNotFoundException as e:
-        sdlog.info("SDNEXTUR-001","Cannot switch url for %s (FileNotFoundException)"%(tr.file_functional_id,))
+        sdlog.info("SDNEXTUR-003","Cannot switch url for %s (FileNotFoundException)"%(tr.file_functional_id,))
         return False
     except sdexception.NextUrlNotFoundException as e:
-        sdlog.info("SDNEXTUR-002","Cannot switch url for %s (NextUrlNotFoundException)"%(tr.file_functional_id,))
+        sdlog.info("SDNEXTUR-004","Cannot switch url for %s (NextUrlNotFoundException)"%(tr.file_functional_id,))
         return False
     except Exception as e:
-        sdlog.info("SDNEXTUR-003","Unknown exception (file_functional_id=%s,exception=%s)"%(tr.file_functional_id,str(e)))
+        sdlog.info("SDNEXTUR-005","Unknown exception (file_functional_id=%s,exception=%s)"%(tr.file_functional_id,str(e)))
         conn.close()
         return False
     finally:
@@ -62,13 +62,13 @@ def run(tr):
 
 def next_url(tr,conn):
     all_urlps=get_urls(tr.file_functional_id) # [[url1,protocol1],[url2,protocol2],...]
-    sdlog.info("JFPNEXTUR-03","all_urpls= %s"%(all_urlps,))
+    sdlog.info("SDNEXTUR-006","all_urpls= %s"%(all_urlps,))
     c = conn.cursor()
     fus = c.execute("SELECT url FROM failed_url WHERE file_id="+
                   "(SELECT file_id FROM file WHERE file_functional_id=?)",
                     (tr.file_functional_id,))
     failed_urls = [fu[0] for fu in fus.fetchall()]
-    sdlog.info("JFPNEXTUR-04","failed_urls= %s"%(failed_urls,))
+    sdlog.info("SDNEXTUR-007","failed_urls= %s"%(failed_urls,))
     urlps = [urlp for urlp in all_urlps if urlp[0] not in failed_urls]
     # ... Note that list comprehensions preserve order.
     urls=remove_unsupported_url(urlps)
@@ -80,9 +80,9 @@ def next_url(tr,conn):
         old_url=tr.url
         new_url=urls[0]
         tr.url=new_url
-        sdlog.info("SDNEXTUR-004","Url successfully switched (file_functional_id=%s,old_url=%s,new_url=%s)"%(tr.file_functional_id,old_url,new_url))
+        sdlog.info("SDNEXTUR-008","Url successfully switched (file_functional_id=%s,old_url=%s,new_url=%s)"%(tr.file_functional_id,old_url,new_url))
     else:
-        sdlog.info("SDNEXTUR-006","Next url not found (file_functional_id=%s)"%(tr.file_functional_id,))
+        sdlog.info("SDNEXTUR-009","Next url not found (file_functional_id=%s)"%(tr.file_functional_id,))
         raise sdexception.NextUrlNotFoundException()
 
 def remove_unsupported_url(urlps):
@@ -92,9 +92,26 @@ def remove_unsupported_url(urlps):
 def get_urls(file_functional_id):
     """returns a prioritized list of [url,protocol] where each url can supply the specified file"""
 
-    result=sdquicksearch.run(parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%file_functional_id],post_pipeline_mode=None)
+    try:
+        result=sdquicksearch.run(
+            parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%
+                       file_functional_id],
+            post_pipeline_mode=None )
+    except Exception as e:
+        sdlog.debug("SDNEXTUR-015", "exception %s.  instance_id=%s"%(e,file_functional_id))
+        raise e
+
     li=result.get_files()
-    sdlog.info("JFPNEXTUR-05","sdquicksearch returned %s sets of file urls: %s"%(len(li),li))
+    sdlog.info("SDNEXTUR-016","sdquicksearch returned %s sets of file urls: %s"%(len(li),li))
+    if li==[]:
+        # No urls found. Try again, but wildcard the file id. (That leads to a string search on all
+        # fields for the wildcarded file id, rather than a match of the instance_id field only.)
+        result=sdquicksearch.run(
+            parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%
+                       file_functional_id+'*'],
+            post_pipeline_mode=None )
+        li=result.get_files()
+        sdlog.info("SDNEXTUR-017","sdquicksearch 2nd call %s sets of file urls: %s"%(len(li),li))
     # result looks like
     # [ {protocol11:url11, protocol12:url12, attached_parameters:dict, score:number, type:'File',
     #    size:number} }, {[another dict of the same format}, {another dict},... ]
@@ -105,8 +122,11 @@ def get_urls(file_functional_id):
 
     urlps = []
     for dic in li:
-        urlps += [ [dic[key],key] for key in dic.keys() if key.find('url_')>=0 ]
+        urlps += [ [dic[key],key] for key in dic.keys() if key.find('url_')>=0 and
+                   dic[key].find('//None')<0 ]
         # ... protocol keys are one of 'url_opendap', 'url_http', 'url_gridftp'
+        # The search for //None bypasses an issue with the SOLR lookup where there is no
+        # url_gridftp possibility.
 
     return prioritize_urlps( urlps )
 
@@ -134,4 +154,5 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     file_functional_id='cmip5.output1.LASG-CESS.FGOALS-g2.decadal1985.day.atmos.day.r1i1p1.v1.va_day_FGOALS-g2_decadal1985_r1i1p1_19880101-19881231.nc'
-    print get_urls(file_functional_id)
+    from pprint import pprint
+    pprint( get_urls(file_functional_id) )

--- a/sdt/bin/sdremotequtils.py
+++ b/sdt/bin/sdremotequtils.py
@@ -57,6 +57,16 @@ def serialize_parameter__ovpp(name,values): # 'ovpp' means one value per paramet
 
     assert isinstance(values,list)
 
+    if name=="instance_id" and values[0][-1]=='*':
+        # Special case, replace instance_id match with a string search because we need wildcards.
+        # (The '*' at the end of the instance_id value signals the need for wildcards.)
+        # That's because when the SOLR index is built, sometimes the name is changed (by suffixing
+        # "_0" or "_1", etc.) to preserve uniqueness.  And only string search supports wildcards.
+        #sdlog.info("JFPRMTQUTS01","name=%s, values=%s"%(name,values))
+        name = "query"
+        values = [ "id:" + v + "*" for v in values ]
+        #sdlog.info("JFPRMTQUTS02","name=%s, values=%s"%(name,values))
+
     for v in values:
         l.append(name+"="+v)
 


### PR DESCRIPTION
Sometimes the SOLR index has changed filenames (e.g., a suffix "_3" might be added to ensure uniqueness).  Then a file can be found only if you use wildcards.  That in turn requires a text search.  The changes in this branch make that happen when the first attempt to get a file has failed, and thereafter the index node could not provide information on the file.  There also are some minor changes in sdnexturl.py, mostly for appearance but one  bypasses another rare problem with using the SOLR index.