### PR TITLE
Downgrade setuptools to support Python 2.7

### DIFF
--- a/sdc/install.sh
+++ b/sdc/install.sh
@@ -369,6 +369,7 @@ install_ve ()
     cd ${virtual_env_package_name}
     $PYTHON_CMD virtualenv.py --distribute --unzip-setuptools $ve_dest_dir
     source $ve_dest_dir/bin/activate # set PATH to the ve python
+    pip install --upgrade setuptools==44.0
 }
 
 fix_myproxyclient ()


### PR DESCRIPTION
The script, sdc/install.sh, always installs the latest version of setuptools. On Jan 11, 2020, setuptools 45.0, which does not support Python 2.7, was released. It breaks the Synda installer. This pull request downgrades setuptools to version 44.0 (which supports Python 2.7).