### PR TITLE
Remove TLSv1 version pinning

### DIFF
--- a/sdt/bin/sdget.sh
+++ b/sdt/bin/sdget.sh
@@ -308,8 +308,6 @@ fi
 # Don't check the server certificate against the available certificate authorities.  Also don't require the URL host name to match the common name presented by the certificate.
 NO_CHECK_SERVER_CERTIFICATE=" --no-check-certificate "
 #NO_CHECK_SERVER_CERTIFICATE=" "
-TLS_ONLY=" --secure-protocol=TLSv1 "
-#TLS_ONLY=" "
 g__lifetime=168
 
 # prevent download if local file path not starting with '/'
@@ -350,12 +348,10 @@ if [ $USE_CERTIFICATE = "yes" ]; then
     WGET_CMD="wget $WGETOPT \
         --certificate=$ESGF_CREDENTIAL --private-key=$ESGF_CREDENTIAL --ca-directory=$ESGF_CERT_DIR --ca-certificate=$ESGF_CREDENTIAL \
         $NO_CHECK_SERVER_CERTIFICATE \
-        $TLS_ONLY \
         $url"
 else
     WGET_CMD="wget $WGETOPT \
         $NO_CHECK_SERVER_CERTIFICATE \
-        $TLS_ONLY \
         $url"
 fi
 


### PR DESCRIPTION
This PR fixes the following issue: #92 

### Justification
Several downloads have been failing for me due to a hard-coded TLSv1 version in the synda request. The error being that ESGF authorization credentials were not accepted. I'm not sure if there are servers that still demand this protocol, but looking through the revision history of the file, I can see that this options has been set in place for for >5 years.

### Additional Information
This tool has been integral to me for collecting and maintaining the archives of CORDEX and CMIP5 data of my employer. Great work!