### PR TITLE
Caching to speed up sdfiledao.get_files()

### DIFF
--- a/sdt/bin/sdconst.py
+++ b/sdt/bin/sdconst.py
@@ -222,3 +222,6 @@ SECURITY_DIR_MIXED='mixed'
 
 #Synda release parameters
 SYNDA_VERSION = '3.10'
+
+# miscellaneous
+GET_FILES_CACHING = True   # change to False to disable caching logic in sdfiledao.get_files.

--- a/sdt/bin/sdfiledao.py
+++ b/sdt/bin/sdfiledao.py
@@ -29,7 +29,8 @@ def update_transfer_last_access_date(i__date,i__transfer_id,conn=sddb.conn):
     c.close()
 
 def add_file(file,commit=True,conn=sddb.conn):
-    keys_to_insert=['status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id', 'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model', 'data_node', 'dataset_id', 'insertion_group_id', 'timestamp', 'searchapi_host']
+    keys_to_insert=['status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id', 'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model', 'data_node', 'dataset_id', 'insertion_group_id', 'timestamp']
+    # for future:, 'searchapi_host']
 
     if not sdconst.GET_FILES_CACHING:
         return sdsqlutils.insert(file,keys_to_insert,commit,conn)
@@ -262,7 +263,7 @@ def update_file(file,commit=True,conn=sddb.conn):
     # 'url' needs to be present when 'sdnexturl' feature is enabled
     if sdconfig.next_url_on_error:
         keys.append('url')
-        keys.append('searchapi_host')
+        # for future: keys.append('searchapi_host')
 
     rowcount=sdsqlutils.update(file,keys,commit,conn)
 

--- a/sdt/bin/sdfiledao.py
+++ b/sdt/bin/sdfiledao.py
@@ -17,6 +17,10 @@ import sddb
 import sdconfig
 import sdsqlutils
 from sdtypes import File
+import sdlog
+from sdtime import SDTimer
+import sdconst
+import sdsqlitedict
 
 def update_transfer_last_access_date(i__date,i__transfer_id,conn=sddb.conn):
     # no commit here (will be committed in updatelastaccessdate())
@@ -25,8 +29,21 @@ def update_transfer_last_access_date(i__date,i__transfer_id,conn=sddb.conn):
     c.close()
 
 def add_file(file,commit=True,conn=sddb.conn):
-    keys_to_insert=['status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id', 'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model', 'data_node', 'dataset_id', 'insertion_group_id', 'timestamp']
-    return sdsqlutils.insert(file,keys_to_insert,commit,conn)
+    keys_to_insert=['status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id', 'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model', 'data_node', 'dataset_id', 'insertion_group_id', 'timestamp', 'searchapi_host']
+
+    if not sdconst.GET_FILES_CACHING:
+        return sdsqlutils.insert(file,keys_to_insert,commit,conn)
+    else:
+        id_ = sdsqlutils.insert(file,keys_to_insert,commit,conn)
+
+        priority = file.__dict__['priority']
+        data_node = file.__dict__['data_node']
+        hipri = highest_waiting_priority( data_node )
+        if hipri is None or priority>hipri:
+            # Compute cached max(priority) for the data node, ignoring any previous value.
+            highest_waiting_priority( data_node, True )
+
+        return id_
 
 def delete_file(tr,commit=True,conn=sddb.conn):
     c = conn.cursor()
@@ -99,22 +116,119 @@ def get_files(limit=None,conn=sddb.conn,**search_constraints): # don't change ar
       - one search constraint must be given at least
       - if 'limit' is None, retrieve all records matching the search constraints
     """
+    gfs0 = SDTimer.get_time()
+
+    data_node = search_constraints.get('data_node',None)
+
+    # Is the cache applicable to this situation?  Then use it, unless it's empty.
+    if set(search_constraints.keys())==set(['status','data_node']) and\
+       search_constraints['status']==sdconst.TRANSFER_STATUS_WAITING and\
+       limit==1 and\
+       sdconst.GET_FILES_CACHING:
+        # ...limit==1 isn't essential, but the present coding is for limit==1
+        use_cache = True
+        if len( get_files.files.get( data_node, [] ) )>0:
+            gfs1 = SDTimer.get_elapsed_time( gfs0, show_microseconds=True )
+            sdlog.info("SDFILDAO-200","get_files time is %s, used cache, data_node %s"%\
+                       (gfs1,data_node))
+            return [ get_files.files[data_node].pop(0) ]
+        else:
+            cachelen = 100
+            limit += cachelen
+    else:
+        use_cache = False
+
     files=[]
+    c = conn.cursor()
 
     search_placeholder=sdsqlutils.build_search_placeholder(search_constraints)
-    orderby="priority DESC, checksum"
     limit_clause="limit %i"%limit if limit is not None else ""
 
-    c = conn.cursor()
-    q="select * from file where %s order by %s %s"%(search_placeholder,orderby,limit_clause)
+    getfirst = priority_clause( data_node, use_cache, c )
+    if getfirst=='':
+        return []
+    q="select * from file where %s %s %s"%(search_placeholder,getfirst,limit_clause)
     c.execute(q,search_constraints)
     rs=c.fetchone()
+
+    #if use_cache and (rs is None or len(rs)==0):
+    if use_cache and (rs is None or len(rs)==0):
+        # No files found.  Possibly we could find one if we retry at another priority level.
+        # Note that it makes no sense to do this if getfirst==''.  That has alread triggered
+        # an early return.
+        highest_waiting_priority( data_node, c )   # compute the priority to retry at
+        getfirst = priority_clause( data_node, use_cache, c )
+        q="select * from file where %s %s %s"%(search_placeholder,getfirst,limit_clause)
+        c.execute(q,search_constraints)
+        rs = c.fetchone()
+
     while rs!=None:
         files.append(sdsqlutils.get_object_from_resultset(rs,File))
         rs=c.fetchone()
     c.close()
 
+    if len(files)>1 and use_cache:
+        # We shall return one of the files and cache the rest.
+        get_files.files[ data_node ] = files[1:]
+        files = files[0:1]
+
+    gfs1 = SDTimer.get_elapsed_time( gfs0, show_microseconds=True )
+    sdlog.info("SDFILDAO-200","get_files time is %s, search %s with %s"%(gfs1,q,search_constraints))
     return files
+get_files.files = {}
+
+def priority_clause( data_node, use_cache, cursor ):
+    if use_cache:
+        pri = highest_waiting_priority(data_node)
+        if pri is None:
+            getfirst = ''
+        else:
+            getfirst = "AND priority=%s" % pri
+    else:
+        getfirst = "ORDER BY priority DESC, checksum"
+    return getfirst
+
+def highest_waiting_priority( data_node, cursor=None, connection=sddb.conn ):
+    """This function contains a dictionary-like cache of the highest priority among status='waiting'
+    files for each data_node.  It will always return the dictionary value for the specified
+    data node, or one of the specified data nodes if several are provided.
+    - When called with a data_node and cursor, it will update its value for that data_node.
+    - If cursor==True, then this function will create and close its own cursor.
+    - If data_node==True, then this function will be applied to all data nodes.
+    """
+    if cursor is None:
+        return (highest_waiting_priority.vals).get(data_node,None)
+    else:
+        if cursor==True:
+            c = connection.cursor()
+        else:
+            c = cursor
+        if data_node==True:
+            q = "SELECT data_node FROM file GROUP BY data_node"
+            c.execute(q)
+            data_nodes = [tup[0] for tup in c.fetchall()]
+        else:
+            data_nodes = [data_node]
+        for dn in data_nodes:
+            hwp0 = SDTimer.get_time()
+            q = "SELECT MAX(priority) FROM file WHERE status='waiting' AND data_node='%s'" % dn
+            c.execute(q)
+            val = c.fetchone()
+            if len(val)>0:
+                highest_waiting_priority.vals[dn] = val[0]
+            else:
+                highest_waiting_priority.vals.pop(dn,None)
+            hwp1 = SDTimer.get_elapsed_time( hwp0, show_microseconds=True )
+            #sdlog.info("SDFILDAO-300","time %s to recompute priority=%s for %s" %
+            #           (hwp1,val[0],dn) )
+            #sdlog.info("SDFILDAO-301","  query %s" % q )
+        if cursor==True:
+            c.close()
+        return (highest_waiting_priority.vals).get(data_nodes[0],None)
+# The cache is a database masquerading as a dictionary.  A real dictionary in memory would be:
+# highest_waiting_priority.vals = {}
+highest_waiting_priority.vals=sdsqlitedict.SqliteStringDict(
+    sdconfig.default_db_folder+"/caches.db", 'maxpri', None )
 
 def get_dataset_files(d,conn=sddb.conn,limit=None):
     """
@@ -143,11 +257,12 @@ def get_dataset_files(d,conn=sddb.conn,limit=None):
     return files
 
 def update_file(file,commit=True,conn=sddb.conn):
-    keys=['status','error_msg','sdget_status','sdget_error_msg','start_date','end_date','duration','rate']
+    keys=['status','error_msg','sdget_status','sdget_error_msg','start_date','end_date','duration','rate','priority']
 
-    # 'url' need to be present when 'sdnexturl' feature is enabled
+    # 'url' needs to be present when 'sdnexturl' feature is enabled
     if sdconfig.next_url_on_error:
         keys.append('url')
+        keys.append('searchapi_host')
 
     rowcount=sdsqlutils.update(file,keys,commit,conn)
 

--- a/sdt/bin/sdmodifyquery.py
+++ b/sdt/bin/sdmodifyquery.py
@@ -16,6 +16,8 @@ import string
 import sdapp
 import sddb
 import sdlog
+import sdconst
+import sdfiledao
 
 def change_replica(file_functional_id,new_replica,conn=sddb.conn):
     (url,data_node)=new_replica
@@ -29,9 +31,13 @@ def change_status(old_status,new_status,conn=sddb.conn):
     nbr=0
 
     c=conn.cursor()
-    res=c.execute("update file set error_msg=NULL,status=?,sdget_error_msg=NULL,sdget_status=NULL where status=?",(new_status,old_status,))
+    res=c.execute(
+        "update file set error_msg=NULL,status=?,sdget_error_msg=NULL,sdget_status=NULL where status=?",
+        (new_status,old_status,))
     nbr=c.rowcount
     conn.commit()
+    if new_status==sdconst.TRANSFER_STATUS_WAITING and sdconst.GET_FILES_CACHING:
+        sdfiledao.highest_waiting_priority( True, c )
     c.close()
 
     return nbr

--- a/sdt/bin/sdtime.py
+++ b/sdt/bin/sdtime.py
@@ -111,7 +111,7 @@ class SDTimer():
         return datetime.datetime.now()
 
     @classmethod
-    def get_elapsed_time(cls,start_time):
+    def get_elapsed_time(cls,start_time,show_microseconds=False):
         """
         Returns:
             duration (in seconds)
@@ -119,7 +119,10 @@ class SDTimer():
         stop_time=datetime.datetime.now()
         delt=stop_time-start_time
 
-        return (delt.microseconds + (delt.seconds + delt.days * 24 * 3600) * 10**6) / 10**6 # microsecond is present here, but disappear after the last division. duration unit is second.
+        if show_microseconds:
+            return (delt.microseconds*1.0 + (delt.seconds + delt.days * 24 * 3600) * 10**6) / 10**6
+        else:
+            return (delt.microseconds + (delt.seconds + delt.days * 24 * 3600) * 10**6) / 10**6 # microsecond is present here, but disappear after the last division. duration unit is second.
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
These changes dramatically improved data transfer performance in my case (large database, many parallel downloads from several data nodes).   The only downside is if you are manually tweaking priorities, your tweaks won't take effect unless you do something more (e.g. a retry).  You can turn off all these changes by setting sdconst.GET_FILES_CACHING=False.