### PR TITLE
Retry for just one data node (or a few)

### DIFF
--- a/sdt/bin/sdmodify.py
+++ b/sdt/bin/sdmodify.py
@@ -34,9 +34,10 @@ def pause_all():
     nbr=sdmodifyquery.change_status(sdconst.TRANSFER_STATUS_WAITING,sdconst.TRANSFER_STATUS_PAUSE)
     sdlog.info("SDMODIFY-830","%i transfer marked for retry"%(nbr))
 
-def retry_all(filter=None):
+def retry_all( filter=None ):
     sdlog.info("SDMODIFY-343","Moving transfer from error to waiting..")
-    nbr=sdmodifyquery.change_status(sdconst.TRANSFER_STATUS_ERROR,sdconst.TRANSFER_STATUS_WAITING)
+    nbr=sdmodifyquery.change_status( sdconst.TRANSFER_STATUS_ERROR,sdconst.TRANSFER_STATUS_WAITING,
+                                     where=filter )
     sdlog.info("SDMODIFY-226","%i transfer marked for retry"%(nbr))
     return nbr
 

--- a/sdt/bin/sdmodifyquery.py
+++ b/sdt/bin/sdmodifyquery.py
@@ -25,11 +25,31 @@ def change_replica(file_functional_id,new_replica,conn=sddb.conn):
     conn.commit()
     c.close()
 
-def change_status(old_status,new_status,conn=sddb.conn):
+def get_where_clause( where='' ):
+    assert( where.find("'")<0 )  # protect against a nasty user error
+    assert( where.find('"') )<0  # protect against a nasty user error
+    if where=='' or where is None:
+        where_clause = ''
+    elif where.find(' ')>0:
+        # arbitrary SQL expression
+        where_clause = " AND ("+where+")"
+    elif where.find('.')>0:
+        # data_node specified
+        where_clause = " AND data_node='%s'" % where
+    else:
+        # data_node substring specified
+        where_clause = " AND data_node LIKE %s%s%s" % ("'%",where,"%'")
+    return where_clause
+
+def change_status(old_status,new_status,conn=sddb.conn,where=''):
     nbr=0
 
+    where_clause = get_where_clause( where )
     c=conn.cursor()
-    res=c.execute("update file set error_msg=NULL,status=?,sdget_error_msg=NULL,sdget_status=NULL where status=?",(new_status,old_status,))
+    res=c.execute(
+        "update file set error_msg=NULL,status=?,sdget_error_msg=NULL,sdget_status=NULL WHERE "+\
+        "status=?"+where_clause,
+        (new_status,old_status,))
     nbr=c.rowcount
     conn.commit()
     c.close()

--- a/sdt/bin/sdmodifyquery.py
+++ b/sdt/bin/sdmodifyquery.py
@@ -28,19 +28,20 @@ def change_replica(file_functional_id,new_replica,conn=sddb.conn):
     c.close()
 
 def get_where_clause( where='' ):
-    assert( where.find("'")<0 )  # protect against a nasty user error
-    assert( where.find('"') )<0  # protect against a nasty user error
     if where=='' or where is None:
         where_clause = ''
-    elif where.find(' ')>0:
-        # arbitrary SQL expression
-        where_clause = " AND ("+where+")"
-    elif where.find('.')>0:
-        # data_node specified
-        where_clause = " AND data_node='%s'" % where
     else:
-        # data_node substring specified
-        where_clause = " AND data_node LIKE %s%s%s" % ("'%",where,"%'")
+      assert( where.count("'")%2==0 )  # protect against a nasty user error
+      assert( where.find('"') )<0  # protect against a nasty user error
+      if where.find(' ')>0:
+          # arbitrary SQL expression
+          where_clause = " AND ("+where+")"
+      elif where.find('.')>0:
+          # data_node specified
+          where_clause = " AND data_node='%s'" % where
+      else:
+          # data_node substring specified
+          where_clause = " AND data_node LIKE %s%s%s" % ("'%",where,"%'")
     return where_clause
 
 def change_status(old_status,new_status,conn=sddb.conn,where=''):

--- a/sdt/bin/sdsubparser.py
+++ b/sdt/bin/sdsubparser.py
@@ -187,9 +187,6 @@ def run(subparsers):
     subparser=subparsers.add_parser('help',help='Show help')
     subparser.add_argument('topic',nargs='?')
 
-    subparser=create_subparser(subparsers, 'check-env', help='Checks install environment.')
-    subparser=create_subparser(subparsers, 'init-env', help='Initilizes install environment.')
-
     subparser=create_subparser(subparsers,'history',common_option=False,help='Show history')
 
     subparser=create_subparser(subparsers,'install',help='Download dataset (async)',note=sdi18n.m0022,example=sdcliex.install())
@@ -238,6 +235,9 @@ def run(subparsers):
 
     subparser=create_subparser(subparsers,'reset',common_option=False,help="Remove all 'waiting' and 'error' transfers")
     subparser=create_subparser(subparsers,'retry',common_option=False,help='Retry transfer (switch status from error to waiting)')
+    subparser.add_argument('-w','--where',default=None,help="Restrict the retry to one data_node, e.g. 'esgf3.dkrz.de' or 'dkrz'.  Spaces are not allowed.")
+    #...fairly arbitrary SQL expressions are also allowed, but not documented here because
+    # they are prone to user error
 
     subparser=create_subparser(subparsers,'search',help='Search dataset',example=sdcliex.search('synda search'))
     add_parameter_argument(subparser)
@@ -259,10 +259,6 @@ def run(subparsers):
     add_parameter_argument(subparser)
     add_incremental_mode_argument(subparser,'stat')
     add_timestamp_boundaries(subparser,hidden=True) # hidden option mainly used for test and debug
-
-    subparser=create_subparser(subparsers, 'token',common_option=False,help='Get OAuth2 tokens')
-    subparser.add_argument('-p', '--provider',choices=['globus'],default='globus',help='Get Globus OAuth2 tokens')
-    add_action_argument(subparser,choices=['renew', 'print'])
 
     subparser=create_subparser(subparsers,'update',common_option=False,help='Update ESGF parameter local cache')
     subparser.add_argument('-i','--index_host',help='Retrieve parameters from the specified index')

--- a/sdt/bin/sdsubparser.py
+++ b/sdt/bin/sdsubparser.py
@@ -187,6 +187,9 @@ def run(subparsers):
     subparser=subparsers.add_parser('help',help='Show help')
     subparser.add_argument('topic',nargs='?')
 
+    subparser=create_subparser(subparsers, 'check-env', help='Checks install environment.')
+    subparser=create_subparser(subparsers, 'init-env', help='Initilizes install environment.')
+
     subparser=create_subparser(subparsers,'history',common_option=False,help='Show history')
 
     subparser=create_subparser(subparsers,'install',help='Download dataset (async)',note=sdi18n.m0022,example=sdcliex.install())
@@ -259,6 +262,10 @@ def run(subparsers):
     add_parameter_argument(subparser)
     add_incremental_mode_argument(subparser,'stat')
     add_timestamp_boundaries(subparser,hidden=True) # hidden option mainly used for test and debug
+
+    subparser=create_subparser(subparsers, 'token',common_option=False,help='Get OAuth2 tokens')
+    subparser.add_argument('-p', '--provider',choices=['globus'],default='globus',help='Get Globus OAuth2 tokens')
+    add_action_argument(subparser,choices=['renew', 'print'])
 
     subparser=create_subparser(subparsers,'update',common_option=False,help='Update ESGF parameter local cache')
     subparser.add_argument('-i','--index_host',help='Retrieve parameters from the specified index')

--- a/sdt/bin/sdtiaction.py
+++ b/sdt/bin/sdtiaction.py
@@ -129,14 +129,7 @@ def check(args):
 
 def config(args):
     import sdconfig
-    if args.action is None:
-        sdconfig.print_()
-    else:
-        if args.action=='get':
-            sdconfig.print_(args.name)
-        elif args.action=='set':
-            # TODO see if section can be added to the argparser arguments.
-            print('Feature not implemented yet.')
+    sdconfig.print_(args.name)
 
 def contact(args):
     import sdi18n
@@ -447,7 +440,7 @@ def replica(args):
 
 def retry(args):
     import sdmodify
-    nbr=sdmodify.retry_all()
+    nbr=sdmodify.retry_all( filter=args.where )
     if nbr>0:
         print_stderr("%i file(s) marked for retry."%nbr)
     else:
@@ -601,7 +594,7 @@ def pexec(args):
 
         if dataset_found_count>0:
             if order_dataset_count==0 and order_variable_count==0:
-                print_stderr("Data not ready (data must be already downloaded before performing pexec task): operation cancelled")
+                print_stderr("Data not ready (data must be already downloaded before performing pexec task): operation cancelled")   
             else:
                 sdhistorydao.add_history_line(sdconst.ACTION_PEXEC,selection_filename)
 
@@ -675,20 +668,6 @@ def queue(args):
 
     print tabulate(li,headers=['status','count','size'],tablefmt="plain")
     #sddaemon.print_daemon_status()
-
-def token(args):
-    import sdtoken
-    if args.action is None:
-        sdtoken.print_tokens()
-        return 0
-    if args.action == 'renew':
-        sdtoken.renew_tokens()
-        return 0
-    if args.action == 'print':
-        sdtoken.print_tokens()
-        return 0
-    print_stderr("Not implemented")
-    return 1
 
 def update(args):
     print_stderr("Retrieving parameters from ESGF...")
@@ -770,22 +749,7 @@ def watch(args):
     else:
         print_stderr('Daemon not running')
 
-def checkenv(args):
-    from sdsetuputils import PostInstallCommand
-    pic = PostInstallCommand()
-    pic.run()
-
 # init.
-# def initenv(args):
-#     """
-#     should find the tar data.tar.bz and untar it
-#     :param args:
-#     :return:
-#     """
-#     from sdsetuputils import EnvInit
-#     ei = EnvInit()
-#     ei.run()
-
 
 # TODO: rename as subcommands
 actions={
@@ -811,11 +775,8 @@ actions={
     'retry':retry,
     'selection':selection, 
     'stat':stat, 
-    'token':token,
     'update':update,
     'upgrade':upgrade,
     'variable':variable,
-    'watch':watch,
-    'check-env': checkenv
-    # 'init-env': initenv
+    'watch':watch
 }

--- a/sdt/bin/sdtiaction.py
+++ b/sdt/bin/sdtiaction.py
@@ -129,7 +129,14 @@ def check(args):
 
 def config(args):
     import sdconfig
-    sdconfig.print_(args.name)
+    if args.action is None:
+        sdconfig.print_()
+    else:
+        if args.action=='get':
+            sdconfig.print_(args.name)
+        elif args.action=='set':
+            # TODO see if section can be added to the argparser arguments.
+            print('Feature not implemented yet.')
 
 def contact(args):
     import sdi18n
@@ -594,7 +601,7 @@ def pexec(args):
 
         if dataset_found_count>0:
             if order_dataset_count==0 and order_variable_count==0:
-                print_stderr("Data not ready (data must be already downloaded before performing pexec task): operation cancelled")   
+                print_stderr("Data not ready (data must be already downloaded before performing pexec task): operation cancelled")
             else:
                 sdhistorydao.add_history_line(sdconst.ACTION_PEXEC,selection_filename)
 
@@ -668,6 +675,20 @@ def queue(args):
 
     print tabulate(li,headers=['status','count','size'],tablefmt="plain")
     #sddaemon.print_daemon_status()
+
+def token(args):
+    import sdtoken
+    if args.action is None:
+        sdtoken.print_tokens()
+        return 0
+    if args.action == 'renew':
+        sdtoken.renew_tokens()
+        return 0
+    if args.action == 'print':
+        sdtoken.print_tokens()
+        return 0
+    print_stderr("Not implemented")
+    return 1
 
 def update(args):
     print_stderr("Retrieving parameters from ESGF...")
@@ -749,7 +770,22 @@ def watch(args):
     else:
         print_stderr('Daemon not running')
 
+def checkenv(args):
+    from sdsetuputils import PostInstallCommand
+    pic = PostInstallCommand()
+    pic.run()
+
 # init.
+# def initenv(args):
+#     """
+#     should find the tar data.tar.bz and untar it
+#     :param args:
+#     :return:
+#     """
+#     from sdsetuputils import EnvInit
+#     ei = EnvInit()
+#     ei.run()
+
 
 # TODO: rename as subcommands
 actions={
@@ -775,8 +811,11 @@ actions={
     'retry':retry,
     'selection':selection, 
     'stat':stat, 
+    'token':token,
     'update':update,
     'upgrade':upgrade,
     'variable':variable,
-    'watch':watch
+    'watch':watch,
+    'check-env': checkenv
+    # 'init-env': initenv
 }


### PR DESCRIPTION
This change lets you limit the scope of "synda retry", e.g. "synda retry esgf-data2.diasjp.net" or "synda retry dias" (*).  This is useful if there are a large number of 'error' files and you only want a few of them.  For example, when one data node went down and came back up, you only want to retry its 'error' files.

(*) "synda retry [arbitrary SQL expression]" is supported but not encouraged.  A partial data node name with a dot, e.g. "synda retry diasjp.net" is not supported.