### PR TITLE
Let Synda continue after an error trying to renew a certificate

### DIFF
--- a/sdt/bin/sdcfbuilder.py
+++ b/sdt/bin/sdcfbuilder.py
@@ -79,9 +79,12 @@ def create_configuration_file_sample(path):
     config.add_section('download')
     config.set('download', 'max_parallel_download', '8')
     config.set('download', 'max_parallel_download_per_datanode', '8')
+    config.set('download', 'get_only_latest_version', 'true')
     config.set('download', 'hpss', '1')
     config.set('download', 'http_fallback', 'false')
     config.set('download', 'gridftp_opt', '')
+    config.set('download', 'incremental_mode_for_datasets', 'false')
+    config.set('download', 'continue_on_cert_errors', 'false')
 
     config.add_section('post_processing')
     config.set('post_processing', 'host', 'localhost')

--- a/sdt/bin/sdcfloader.py
+++ b/sdt/bin/sdcfloader.py
@@ -34,6 +34,7 @@ def load(configuration_file,credential_file):
 # (pb with options below is that they are available in all sections)
 default_options={'max_parallel_download':'8',
                  'max_parallel_download_per_datanode':'8',
+                 'get_only_latest_version':'true',
                  'user':'',
                  'group':'',
                  'hpss':'0',
@@ -64,7 +65,9 @@ default_options={'max_parallel_download':'8',
                  'nearest_mode':'geolocation',
                  'openid':'https://esgf-node.ipsl.fr/esgf-idp/openid/foo',
                  'password':'foobar',
-                 'incorrect_checksum_action':'remove'}
+                 'incorrect_checksum_action':'remove',
+                 'incremental_mode_for_datasets':'false',
+                 'continue_on_cert_errors':'false'}
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/sdt/bin/sddmdefault.py
+++ b/sdt/bin/sddmdefault.py
@@ -257,7 +257,10 @@ def transfers_begin(transfers):
         sdlogon.renew_certificate(sdconfig.openid,sdconfig.password,force_renew_certificate=False)
     except Exception,e:
         sdlog.error("SDDMDEFA-502","Exception occured while retrieving certificate (%s)"%str(e))
-        raise
+        if sdconfig.config.get_boolean('download','continue_on_cert_errors'):
+            pass  # Try to keep on going, probably a certificate isn't needed.
+        else:
+            raise
 
     for tr in transfers:
         start_transfer_thread(tr)

--- a/sdt/bin/sdtaskscheduler.py
+++ b/sdt/bin/sdtaskscheduler.py
@@ -196,7 +196,12 @@ def event_loop():
 
         except SDException,e:
             sdlog.error("SDTSCHED-920","Error occured while retrieving ESGF certificate",stderr=True)
-            raise
+            sdlog.error("SDTSCHED-921","Exception=%s"%str(e))
+            if sdconfig.config.get_boolean('download','continue_on_cert_errors'):
+                sdlog.error("SDTSCHED-922","  will continue anyway")
+                pass #jfp try to keep on going; for most data nodes we don't need an OpenID.
+            else:
+                raise
 
     sdlog.info("SDTSCHED-902","Transfer daemon is now up and running",stderr=True)
 


### PR DESCRIPTION
Presently, if Synda encounters an error trying to renew a certificate, it quits.

With this change, the user can set a 'download' option 'continue_on_cert_errors'
to 'true' in sdt.conf.  Then Synda will just keep on going.  It defaults to
'false', so you the old behavior if you do not change your config file.
However, for CMIP-6 most data nodes do not require authentication, to it is best
to set continue_on_cert_errors to true and keep on getting the data.

I made these changes because last month the LLNL identity/myproxy server was down for 3-4 days.  That brought down Synda even though the certs were probably ok and most data nodes didn't require them at all.  This won't happen again.