### PR TITLE
Apply the incremental mode when installing datasets

### DIFF
--- a/sdt/bin/sdcfbuilder.py
+++ b/sdt/bin/sdcfbuilder.py
@@ -79,9 +79,12 @@ def create_configuration_file_sample(path):
     config.add_section('download')
     config.set('download', 'max_parallel_download', '8')
     config.set('download', 'max_parallel_download_per_datanode', '8')
+    config.set('download', 'get_only_latest_version', 'true')
     config.set('download', 'hpss', '1')
     config.set('download', 'http_fallback', 'false')
     config.set('download', 'gridftp_opt', '')
+    config.set('download', 'incremental_mode_for_datasets', 'false')
+    config.set('download', 'continue_on_cert_errors', 'false')
 
     config.add_section('post_processing')
     config.set('post_processing', 'host', 'localhost')

--- a/sdt/bin/sdcfloader.py
+++ b/sdt/bin/sdcfloader.py
@@ -34,6 +34,7 @@ def load(configuration_file,credential_file):
 # (pb with options below is that they are available in all sections)
 default_options={'max_parallel_download':'8',
                  'max_parallel_download_per_datanode':'8',
+                 'get_only_latest_version':'true',
                  'user':'',
                  'group':'',
                  'hpss':'0',
@@ -64,7 +65,9 @@ default_options={'max_parallel_download':'8',
                  'nearest_mode':'geolocation',
                  'openid':'https://esgf-node.ipsl.fr/esgf-idp/openid/foo',
                  'password':'foobar',
-                 'incorrect_checksum_action':'remove'}
+                 'incorrect_checksum_action':'remove',
+                 'incremental_mode_for_datasets':'false',
+                 'continue_on_cert_errors':'false'}
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/sdt/bin/sdremoteqbuilder.py
+++ b/sdt/bin/sdremoteqbuilder.py
@@ -115,11 +115,16 @@ def transform_facets_for_dataset_timestamp_retrieval(facets):
     #      https://esgf-data.dkrz.de/esg-search/search?cmor_table=Amon&product=output1&realm=atmos&institute=MOHC&fields=dataset_id,id,timestamp&project=CMIP5&to=2015-11-01T01:00:00Z&time_frequency=mon&experiment=rcp85&distrib=true&model=HadGEM2-ES&type=File&ensemble=r1i1p1&format=application%2Fsolr%2Bjson&limit=9000&offset=0
     #      https://esgf-data.dkrz.de/esg-search/search?project=CMIP5&product=output1&realm=atmos&institute=MOHC&fields=instance_id,timestamp,_timestamp,type,size&cmor_table=Amon&time_frequency=mon&experiment=rcp85&distrib=true&model=HadGEM2-ES&type=Dataset&ensemble=r1i1p1&format=application%2Fsolr%2Bjson&limit=9000&offset=0&replica=false
     #
+    #jfp But when the 'from' facet comes from use of the incremental mode (not from a
+    # --timestamp_left_boundary argument), we know that all older dates have already been covered.
+    # So it's ok to leave in the 'from' facet if the user is ok with it.  Sometimes leaving in
+    # the 'from' facet can save *days* of runtime and thus prevent database locks from killing
+    # other Synda jobs.
     if 'to' in facets_cpy:
         del facets_cpy['to']
-    if 'from' in facets_cpy:
-        del facets_cpy['from']
-
+    if not sdconfig.config.getboolean('download','incremental_mode_for_datasets'):
+        if 'from' in facets_cpy:
+            del facets_cpy['from']
 
     # we also add '_timestamp' as some project use this naming
     # (e.g.ahttp://esgf-index1.ceda.ac.uk/esg-search/search?fields=timestamp,_timestamp&instance_id=cordex.output.EUR-11.DHMZ.ECMWF-ERAINT.evaluation.r1i1p1.RegCM4-2.v1.day.ps.v20150527).


### PR DESCRIPTION
If the user edits sdt.conf to set 'incremental_mode_for_datasets' to ……'true', then the incremental mode (synda install -i ...) will be applied to dataset searches as well as file searches. 
This has a huge performance advantage for large installation jobs,  roughly a factor of 50 in my experience.   That, in turn, reduces the number of database lock errors encountered by synda processes.