### PR TITLE
Logsdget

### DIFF
--- a/sdt/bin/sdget.py
+++ b/sdt/bin/sdget.py
@@ -30,6 +30,7 @@ import sdutils
 import sdconst
 import sdget_urllib
 from sdtools import print_stderr
+import sdlog
 
 def download(url,full_local_path,debug=False,http_client=sdconfig.http_client,timeout=sdconst.ASYNC_DOWNLOAD_HTTP_TIMEOUT,verbosity=0,buffered=True,hpss=False):
     killed=False
@@ -201,6 +202,7 @@ def prepare_args(url,full_local_path,script,debug,timeout,verbosity,hpss):
         li.insert(1,'-p')
         li.insert(2,'0')
 
+    sdlog.debug('SDGET000-010',"sdget command %s"%li)
     return li
 
 # init.

--- a/sdt/bin/sdget.sh
+++ b/sdt/bin/sdget.sh
@@ -354,6 +354,7 @@ else
         $NO_CHECK_SERVER_CERTIFICATE \
         $url"
 fi
+echo WGET_CMD $WGET_CMD
 
 wget_stderr2stdout ()
 {
@@ -455,6 +456,8 @@ fi
 
 if [ $parse_output -eq 1 ]; then
     source "$wgetoutputparser" # we parse wget output to keep only HTTP response code from wget messages
+elif [ $wget_status -ne 0 ]; then
+    log "DEB015" "$wget_errmsg"
 fi
 
 


### PR DESCRIPTION
Log enough about sdget*, wget calls, and wget errors, so that it's possible to reproduce and debug data transfer errors.