### PR TITLE
Do not check Globus tokens when globustransfer is disabled

### DIFF
--- a/sdt/bin/sddirectdownload.py
+++ b/sdt/bin/sddirectdownload.py
@@ -41,13 +41,14 @@ def run(files,
         1 if one or more transfer(s) didn't complete successfully
     """
 
-    """
-    If protocol is set to 'globus' in attached_parameters, download all files
-    with url scheme globus:, or gridftp: provided that there is a gridftp to
-    globus mapping defined in /esg/config/esgf_endpoints.xml. Remaining files
-    will be downloaded usingglobus-url-copy or wget.
-    """
-    files = sdglobus.direct(files, force, local_path_prefix, verify_checksum, network_bandwidth_test, debug, verbosity)
+    if sdconfig.config.getboolean('module','globustransfer'):
+        """
+        If protocol is set to 'globus' in attached_parameters, download all files
+        with url scheme globus:, or gridftp: provided that there is a gridftp to
+        globus mapping defined in /esg/config/esgf_endpoints.xml. Remaining files
+        will be downloaded usingglobus-url-copy or wget.
+        """
+        files = sdglobus.direct(files, force, local_path_prefix, verify_checksum, network_bandwidth_test, debug, verbosity)
 
     failed_count=0
 


### PR DESCRIPTION
The problem with Globus tokens being checked even when "globustransfer" was set to "false" in sdt.conf file was reported in comment https://github.com/Prodiguer/synda/pull/127#issuecomment-606877409. This pull request fix the problem by checking first if globustransfer is set to true in sdt.conf.