### PR TITLE
Robust2ways

### DIFF
--- a/sdt/bin/sdenqueue.py
+++ b/sdt/bin/sdenqueue.py
@@ -138,7 +138,13 @@ def add_file(f):
     f.status=sdconst.TRANSFER_STATUS_WAITING
     f.crea_date=sdtime.now()
 
-    sdfiledao.add_file(f,commit=False)
+    try:
+        sdfiledao.add_file(f,commit=False)
+    except Exception as e:
+        sdlog.error("SDENQUEU-005","Failed to create transfer (local_path=%s,url=%s)"%(f.get_full_local_path(),f.url))
+        sdlog.error("SDENQUEU-006","Exception was %s"%e)
+        sdlog.error("SDENQUEU-007","This file was found from the search url %s"
+                    % getattr(f, 'search_url', '(unknown)') )
 
 def add_dataset(f):
     """

--- a/sdt/bin/sdjson.py
+++ b/sdt/bin/sdjson.py
@@ -25,7 +25,7 @@ def parse_parameters(buffer):
         raise
 
     params={}
-    footer_node=xmldoc["facet_counts"]
+    footer_node=xmldoc.get("facet_counts",{"facet_fields":{}})
     fields_node=footer_node["facet_fields"]
     for facet_name,li in fields_node.iteritems():
         items=[]
@@ -74,10 +74,10 @@ def parse_metadata(buffer):
 
     # retrieve header & footer (those nodes always exist)
     header_node=xmldoc["responseHeader"]
-    footer_node=xmldoc["facet_counts"]
+    # not used: footer_node=xmldoc["facet_counts"]
 
     # parse footer
-    fields_node=footer_node["facet_fields"]
+    # not used: fields_node=footer_node["facet_fields"]
 
     # --- parse body node --- #
 

--- a/sdt/bin/sdnetutils.py
+++ b/sdt/bin/sdnetutils.py
@@ -70,6 +70,8 @@ def call_web_service(url,timeout=sdconst.SEARCH_API_HTTP_TIMEOUT,lowmem=False): 
         raise SDException('SDNETUTI-008','Network error (see log for details)') # we raise a new exception 'network error' here, because most of the time, 'xml parsing error' is due to an 'network error'.
 
     sdlog.debug("SDNETUTI-044","files-count=%d"%len(di.get('files')))
+    for difile in di['files']:
+        difile['search_url'] = url
 
     return sdtypes.Response(call_duration=elapsed_time,lowmem=lowmem,**di) # RAM storage is ok here as one response is limited by SEARCH_API_CHUNKSIZE
 


### PR DESCRIPTION
This pull request fixes Synda's behavior in two situations where it has crashed recently.

1.  In issue 152 is a report of an event in which garbled data from an index node caused an exception in sdfiledao.add_file().  It was not caught, so Synda crashed.  The changes in sdenqueue.py catch any exception form sdfiledao.add_file(), log it, and continue to the next file if any.  To make the log useful, we need to print the search url which led to the problem.  In order to make it available, I added this to the file transfer object; that is a change in sdnetutils.py.

2. After a recent change to ESGF software, we no longer have a guarantee that a search query will return facet_counts.  Now it is returned only "if the user requests specific, comma separated field names, using the “facets” URL parameter. "  This change is presently local to LLNL, but we can expect it to become universal in the near future (it prevents index node failures when traffic is high).  So Synda has to function without crashing when facet_counts is not returned.  Fortunately, the changes required are minimal.