### PR TITLE
Continue on cert errors

### DIFF
--- a/synda/sdt/sddmdefault.py
+++ b/synda/sdt/sddmdefault.py
@@ -344,7 +344,14 @@ def transfers_begin(transfers):
             "Exception occured while retrieving certificate ({})".format(e),
         )
 
-        raise
+        sdlog.error("SDDMDEFA-503","  continue_on_cert_errors=%s"%
+                    preferences.is_download_continue_on_cert_errors )
+        if preferences.is_download_continue_on_cert_errors:
+            sdlog.error("SDDMDEFA-504","Ignoring exception")
+            pass  # Try to keep on going, probably a certificate isn't needed.
+        else:
+            sdlog.error("SDDMDEFA-505","Re-raising exception")
+            raise
 
     for tr in transfers:
         start_transfer_thread(tr)

--- a/synda/source/config/file/user/preferences/dao/create/models.py
+++ b/synda/source/config/file/user/preferences/dao/create/models.py
@@ -110,7 +110,7 @@ class Create(object):
         config.set('download', 'http_fallback', 'false')
         config.set('download', 'gridftp_opt', '')
         # config.set('download', 'incremental_mode_for_datasets', 'false')
-        # config.set('download', 'continue_on_cert_errors', 'false')
+        config.set('download', 'continue_on_cert_errors', 'false')
         config.set('download', 'url_max_buffer_size', '3500')
 
         # nouvelles variables

--- a/synda/source/config/file/user/preferences/models.py
+++ b/synda/source/config/file/user/preferences/models.py
@@ -170,6 +170,10 @@ class Config(Base):
         return self.get_data().getint('download', 'url_max_buffer_size')
 
     @property
+    def continue_on_cert_errors(self):
+        return self.get_data().getboolean('download', 'continue_on_cert_errors')
+
+    @property
     def download_gridftp_opt(self):
         return self.get_data().get('download', 'gridftp_opt')
 

--- a/synda/source/config/file/user/preferences/models.py
+++ b/synda/source/config/file/user/preferences/models.py
@@ -170,7 +170,7 @@ class Config(Base):
         return self.get_data().getint('download', 'url_max_buffer_size')
 
     @property
-    def continue_on_cert_errors(self):
+    def is_download_continue_on_cert_errors(self):
         return self.get_data().getboolean('download', 'continue_on_cert_errors')
 
     @property


### PR DESCRIPTION
This is a replacement for pull request 145, issued in May 2020.  It does the same thing, but request 145 was compatible with the master branch in May, and this is compatible with the current master branch.  If the master branch changes again, I will not redo this request.

The purpose of this patch is to allow use of Synda when a identity server is down, unable to renew certificates; but the existing certificates are still valid.  In this case, Synda can and should continue to work normally - with rare exceptions when a certificate has actually expired.

If the user does nothing, then there is no change from the present behavior of Synda.
But if the user sets "continue_on_cert_errors=true" in the download section of his configuration file, then certificate errors will be essentially ignored.  Specifically, when sddmdefault.transfers_begin() encounters an exception while renewing a certificate, then it will simply continue.

This small change is essential to production-scale operation of Synda for replication, and prevents an occasional confusing error for all uses of Synda.  The reason for requiring a setting in the configuration file is that there is a certain small risk, and the user should be aware of it.