### PR TITLE
Save file transfer error histories for further processing

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,5 +17,5 @@ license: "CECILL-1.0"
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/Prodiguer/synda"
 title: Synda
-version: "3.10"
+version: "3.11"
 ...0

--- a/synda/sdt/sdapp.py
+++ b/synda/sdt/sdapp.py
@@ -22,5 +22,5 @@ import sdapputils
 os.umask(0002)
 
 name = 'transfer'
-version = '3.10'
+version = '3.11'
 sdapputils.set_exception_handler()

--- a/synda/sdt/sddbversion.py
+++ b/synda/sdt/sddbversion.py
@@ -63,6 +63,13 @@ def upgrade_db(conn,current_db_version,new_db_version):
 
 # -- upgrade procs -- #
 
+def upgrade_311(conn):
+
+    conn.execute("ALTER TABLE file ADD COLUMN error_history")
+    conn.commit()
+
+    sddbversionutils.update_db_version(conn,'3.11')
+
 def upgrade_310(conn):
 
     conn.execute("CREATE TABLE failed_url ( url_id INTEGER PRIMARY KEY, url TEXT, file_id INTEGER)")
@@ -145,6 +152,7 @@ def upgrade_30(conn):
 # init.
 
 upgrade_procs={
+    '3.11': upgrade_311,
     '3.10': upgrade_310,
     '3.9': upgrade_39,
     '3.8': upgrade_38,

--- a/synda/sdt/sdfiledao.py
+++ b/synda/sdt/sdfiledao.py
@@ -310,6 +310,7 @@ def update_file(_file, commit=True, conn=sddb.conn):
     keys = [
         'status',
         'error_msg',
+        'error_history',
         'sdget_status',
         'sdget_error_msg',
         'start_date',


### PR DESCRIPTION
When a file download fails, preserve a dated and abbreviated error description in a new column error_history.  This gives external scripts the information needed to deal with incorrect urls or bad checksums.

For large-scale replication, it is impossible to manually deal with problems affecting individual files, such as an incorrect checksum reported by the data node.  The Synda database as LLNL has over 16,000 files with bad checksums and over 260,000 files which have been needed some kind of individual attention.  To do this, we need (and I have) an external script.

Usually a file should be made to "disappear" if it cannot be downloaded after repeated attempts, and if the transfer failures are for reasons specific to that file.  By "disappear" I mean that there will be no more attempts to transfer it, even after any possible "synda install..." or "synda retry" command.  An easy way to make that happen is to change the database so that the file has a nonstandard status such as "bad_checksum".  In order to do this, you have to know how many transfer attempts there have been, and when.  The changes in this pull request will add this information to the database.

For an example of such an external script, see https://github.com/painter1/Synda-scripts/blob/fad3c1bb5d131bc0a5bb79d1467d789fd4cc28d1/permanent_error_status.py