### PR TITLE
Track searchapi_host and data node prioritization

### DIFF
--- a/synda/sdt/sdenqueue.py
+++ b/synda/sdt/sdenqueue.py
@@ -29,7 +29,7 @@ import sdfiledao
 import sddatasetdao
 import sdutils
 import sdtimestamp
-from sdtypes import Dataset,File
+from sdtypes import Dataset,File,Selection
 import sdsqlutils
 import sdpostpipelineutils
 import sdtime
@@ -181,6 +181,7 @@ def add_file(f):
     )
 
     f.dataset_id = add_dataset(f)
+    f.searchapi_host = Selection.searchapi_host
     f.status = TRANSFER["status"]['waiting']
     f.crea_date = sdtime.now()
 

--- a/synda/sdt/sdfiledao.py
+++ b/synda/sdt/sdfiledao.py
@@ -32,8 +32,10 @@ def update_transfer_last_access_date(i__date,i__transfer_id,conn=sddb.conn):
     c.close()
 
 def add_file(file,commit=True,conn=sddb.conn):
-    keys_to_insert=['status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id', 'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model', 'data_node', 'dataset_id', 'insertion_group_id', 'timestamp']
-    # for future:, 'searchapi_host']
+    keys_to_insert = [
+        'status', 'crea_date', 'url', 'local_path', 'filename', 'file_functional_id', 'tracking_id',
+        'priority', 'checksum', 'checksum_type', 'size', 'variable', 'project', 'model',
+        'data_node', 'dataset_id', 'insertion_group_id', 'timestamp', 'searchapi_host']
 
     if not Internal().is_processes_get_files_caching:
         return sdsqlutils.insert(file,keys_to_insert,commit,conn)
@@ -324,7 +326,7 @@ def update_file(_file, commit=True, conn=sddb.conn):
 
     if next_url_on_error:
         keys.append('url')
-        # for future: keys.append('searchapi_host')
+        keys.append('searchapi_host')
 
     rowcount = sdsqlutils.update(
         _file,

--- a/synda/sdt/sdnexturl.py
+++ b/synda/sdt/sdnexturl.py
@@ -70,6 +70,8 @@ def run(tr):
 
 def next_url(tr,conn):
     all_urlps=get_urls(tr.file_functional_id) # [[url1,protocol1],[url2,protocol2],...]
+    all_urlps=get_urls(tr.file_functional_id,tr.searchapi_host,tr.url)
+    # ... looks like [[url1,protocol1],[url2,protocol2],...]
     sdlog.info("SDNEXTUR-006","all_urpls= %s"%(all_urlps,))
     c = conn.cursor()
     fus = c.execute("SELECT url FROM failed_url WHERE file_id="+
@@ -94,14 +96,14 @@ def next_url(tr,conn):
         raise sdexception.NextUrlNotFoundException()
 
 
-def get_urls(file_functional_id):
+def get_urls(file_functional_id, searchapi_host, old_url):
     """returns a prioritized list of [url,protocol] where each url can supply the specified file"""
 
     try:
         result=sdquicksearch.run(
             parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%
                        file_functional_id],
-            post_pipeline_mode=None )
+            post_pipeline_mode=None, index_host=searchapi_host )
     except Exception as e:
         sdlog.debug("SDNEXTUR-015", "exception %s.  instance_id=%s"%(e,file_functional_id))
         raise e
@@ -114,7 +116,7 @@ def get_urls(file_functional_id):
         result=sdquicksearch.run(
             parameter=['limit=4','fields=%s'%url_fields,'type=File','instance_id=%s'%
                        file_functional_id+'*'],
-            post_pipeline_mode=None )
+            post_pipeline_mode=None, index_host=searchapi_host )
         li=result.get_files()
         sdlog.info("SDNEXTUR-017","sdquicksearch 2nd call %s sets of file urls: %s"%(len(li),li))
     # result looks like

--- a/synda/sdt/sdparse.py
+++ b/synda/sdt/sdparse.py
@@ -21,6 +21,7 @@ import sdbuffer
 import sdprint
 import sdi18n
 import sdearlystreamutils
+import sdlog
 
 from synda.source.config.file.selection.models import Config as SelectionConfig
 from synda.source.config.file.selection.constants import PENDING_PARAMETER
@@ -129,6 +130,16 @@ def build(buffer, load_default=None):
     default_selection.childs.append(project_default_selection)
     # set default_selection as parent of project_default_selection
     project_default_selection.parent = default_selection
+
+    if selection.filename is not None:
+        #sdlog.info('SDPARSE-0001','selection.filename=%s'%selection.filename)
+        #sdlog.info('SDPARSE-0002','searchapi_host facet=%s'%selection.facets.get('searchapi_host'))
+        if selection.facets.get('searchapi_host') is not None and\
+                len(selection.facets['searchapi_host'])>0 and\
+                selection.facets['searchapi_host'][0] is not None:
+            #sdlog.info('SDPARSE-0003','selection %s has searchapi_host=%s'%
+            #           (selection.filename,selection.facets['searchapi_host']))
+            Selection.searchapi_host = selection.facets['searchapi_host'][0]
 
     return selection
 

--- a/synda/sdt/sdpipeline.py
+++ b/synda/sdt/sdpipeline.py
@@ -68,6 +68,8 @@ def build_queries(stream=None,selection=None,path=None,parameter=None,index_host
         if selection is None:
             buffer=sdbuffer.get_selection_file_buffer(path=path,parameter=parameter)
             selection=sdparse.build(buffer,load_default=load_default)
+        if index_host is not None:
+            selection.facets['searchapi_host'] = index_host
 
         stream=selection.merge_facets()
 


### PR DESCRIPTION
Often the user will specify the index node as searchapi_host in a selection file.
As Synda runs, a failure downloading a file may lead to a new search and a retry at whatever url the search discovered.
The new search should use the index node specified in the selection file.  These changes keep track of searchapi_host by including it in the appropriate file and transfer objects.

That change overlaps with an improvement in the prioritization of data nodes in sdnexturl.py.  So this improvement is also included in this branch and pull request.