### PR TITLE
Optionally keep partial search results even after an exception

### DIFF
--- a/synda/sdt/sdinstall.py
+++ b/synda/sdt/sdinstall.py
@@ -51,6 +51,9 @@ def run(args, metadata=None):
             sdlog.info("SYNDINST-006", "Exception occured during installation ('{}')".format(e))
             raise
 
+    if 'status' in metadata.store.__dict__ and metadata.store.status=='incomplete':
+        print_stderr("WARNING: The file search failed part way through.  Proceeding with what was found.")
+        sdlog.warning("SYNDINST-008","Installing from incomplete search results.")
     # in dry-run mode, we stop here
     if args.dry_run:
         return 0, 0

--- a/synda/sdt/sdmts.py
+++ b/synda/sdt/sdmts.py
@@ -22,8 +22,9 @@ import uuid
 import sqlite3
 import contextlib
 import shutil
-from synda.sdt import sddbpagination
 from synda.sdt import sdconfig
+# from synda.sdt import sddbpagination
+# sddbpagination is imported in DatabaseStorage.get_chunks_PAGINATION, to prevent circular imports.
 
 from synda.source.config.path.tree.models import Config as TreePath
 from synda.source.config.file.internal.models import Config as Internal
@@ -106,6 +107,7 @@ class DatabaseStorage(Storage):
 
             self.connect()
             self.create_table()
+            self.status = 'ok'
         else:
             # this case is only to duplicate the object (see copy method)
 
@@ -201,6 +203,7 @@ class DatabaseStorage(Storage):
                 yield li
 
     def get_chunks_PAGINATION(self):
+        from synda.sdt import sddbpagination
         dbpagination=sddbpagination.DBPagination('bla','foo',self.conn)
         dbpagination.reset()
 
@@ -268,6 +271,8 @@ class DatabaseStorage(Storage):
 
         # create new instance
         cpy=DatabaseStorage(dbfile=dbfile_cpy)
+        if 'status' in self.__dict__:
+            cpy.status = self.status
 
         # re-open ori connection
         self.connect()

--- a/synda/source/config/process/constants.py
+++ b/synda/source/config/process/constants.py
@@ -10,6 +10,11 @@
 # as list maybe duplicated in memory at some point in the pipeline, we use a lower value here than SEARCH_API_CHUNKSIZE
 CHUNKSIZE = 5000
 
+# NEVER_RAISE_EXCEPTION=False means that a paginated search should follow the older behavior where
+# an exception will kill the search.  If True, partial information will be returned, with a status
+# flag changed for use elsewhere in the code.
+NEVER_RAISE_EXCEPTION = False
+
 FETCH_MODE_GENERATOR = 'generator'
 
 ADMIN_SUBCOMMANDS = ['autoremove', 'install', 'open', 'pexec', 'remove', 'reset', 'retry', 'update', 'upgrade']


### PR DESCRIPTION
Add an option to save partial search results.  That is, if a paginated search raises an exception, sdproxy.searchAPIProxy.call_web_service__PAGINATION will nevertheless return whatever incomplete results it has, rather than re-raise the exception.

This is very useful for production-scale replication where paginated searches are very large and failures not unknown.  But by default this is turned off because a naive user would not be aware that the search was incomplete.  To turn it on you have
to set the constant NEVER_RAISE_EXCEPTION to True.