### PR TITLE
Set mono_host_retry to True 

### DIFF
--- a/synda/sdt/sdconfig.py
+++ b/synda/sdt/sdconfig.py
@@ -88,7 +88,7 @@ nearest_schedule = 'post'
 # choices : error | warning
 unknown_value_behaviour = 'error'
 
-mono_host_retry = False
+mono_host_retry = True
 proxymt_progress_stat = False
 
 lowmem = True


### PR DESCRIPTION
If mono_host_retry be True, then Synda will retry after an index node fails to respond to a query.   I have found this essential because sometimes the index node is overloaded and is temporarily unable to respond.  I cannot think of a legitimate reason for it to be False, the previous value.   See issue $141, where nobody else seems to know of a reason for it to be False.